### PR TITLE
Fix small code typo in Concurrency documentation

### DIFF
--- a/src/content/Concurrency.js
+++ b/src/content/Concurrency.js
@@ -139,7 +139,7 @@ def main(): Str & Impure =
     let c2 = chan Str 1;
     select {
         case m <- c1 => "one"
-        case m <- c1 => "two"
+        case m <- c2 => "two"
         case _       => "default"
     }`}
                     </Editor>


### PR DESCRIPTION
Came across this while scanning the documentation for something unrelated. Thought I'd fix it :)