### PR TITLE
#50 Reflected syntax changes to the sample code

### DIFF
--- a/src/content/Introduction.js
+++ b/src/content/Introduction.js
@@ -69,7 +69,7 @@ def main(_args: Array[String]): Int32 & Impure =
                     {`/// Returns the area of the polymorphic record \`r\`.
 /// Note that the use of the type variable \`a\` permits the record \`r\`
 /// to have labels other than \`x\` and \`y\`.
-def polyArea[a : Record](r: {x: Int, y: Int | a}): Int = r.x * r.y
+def polyArea[a : RecordRow](r: {x:: Int, y:: Int | a}): Int = r.x * r.y
 
 /// Computes the area of various rectangle records.
 /// Note that some records have additional fields.


### PR DESCRIPTION
This is a fix for this [Issue](https://github.com/flix/programming-flix/issues/50).
I checked the operation with Playgraoud.
<img width="1158" alt="スクリーンショット 2021-12-16 11 02 49" src="https://user-images.githubusercontent.com/828709/146294438-af90ec06-eccb-40b4-963d-c3a9804ed3bf.png">

