### PR TITLE
docs: more helpful lattice semantics example

### DIFF
--- a/src/content/Fixpoints.js
+++ b/src/content/Fixpoints.js
@@ -518,8 +518,8 @@ instance MeetLattice[Sign] {
         LocalVar("x"; Pos).
         LocalVar("y"; Zer).
         LocalVar("z"; Neg).
+        AddStm("r1", "x", "y").
         AddStm("r2", "x", "y").
-        AddStm("r2", "x", "z").
         AddStm("r2", "y", "z").
         LocalVar(r; sum(v1, v2)) :- 
             AddStm(r, x, y), LocalVar(x; v1), LocalVar(y; v2).

--- a/src/content/Fixpoints.js
+++ b/src/content/Fixpoints.js
@@ -518,8 +518,9 @@ instance MeetLattice[Sign] {
         LocalVar("x"; Pos).
         LocalVar("y"; Zer).
         LocalVar("z"; Neg).
-        AddStm("r1", "x", "y").
+        AddStm("r2", "x", "y").
         AddStm("r2", "x", "z").
+        AddStm("r2", "y", "z").
         LocalVar(r; sum(v1, v2)) :- 
             AddStm(r, x, y), LocalVar(x; v1), LocalVar(y; v2).
     };


### PR DESCRIPTION
I've been looking at this example. As part of making sure that I understand what's going on, I changed it so that it doesn't use lattice semantics, i.e. changed all the semicolons to commas. And got exactly the same answer as when using lattice semantics which was ... unhelpful.

This PR modifies the example so that it gives a different result with and without lattice semantics (which should make it more helpful for the next person taking this road).