### PR TITLE
fix: allow page to have small widths on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -6,7 +6,7 @@ body {
 #page {
     margin-left: auto;
     margin-right: auto;
-    width: 50em;
+    max-width: 50em;
     margin-top: 1em;
 }
 


### PR DESCRIPTION
This tweaks the width constraint so that smaller screens can wrap the page content to match the screen width.

## Before

<img src="https://user-images.githubusercontent.com/279572/174043719-7870e6c6-af47-4b72-a4d0-864381f1e98b.png" width="480"/>

## After

<img src="https://user-images.githubusercontent.com/279572/174043716-7519ce11-3a5a-4e4c-8860-2c6daea1023f.png" width="480"/>